### PR TITLE
Python 3.12 version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v1
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - uses: hashicorp/setup-terraform@v1
       - uses: actions/checkout@v2
       - run: make build
@@ -17,20 +17,20 @@ jobs:
     runs-on: ubuntu-latest
     name: lint
     steps:
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v1
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - uses: hashicorp/setup-terraform@v1
       - uses: actions/checkout@v2
       - run: make lint
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v1
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - uses: hashicorp/setup-terraform@v1
       - uses: actions/checkout@v2
       - run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Python 3.9
+    - name: Set up Python 3.12
       uses: actions/setup-python@v1
       with:
-        python-version: '3.9'
+        python-version: '3.12'
 
     - uses: hashicorp/setup-terraform@v1
     

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,12 @@ format:
 	terraform fmt; \
 	make -C lambda_function format
 
+#docs: @ Update README with terraform-docs
+docs:
+	@exec >&2; \
+	echo "> Updating docs."; \
+	terraform-docs markdown . --output-file README.md
+
 #lint: @ Lint package
 lint:
 	@exec >&2; \

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [archive_file.this](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/resources/file) | resource |
 | [aws_cloudwatch_event_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
@@ -80,6 +79,7 @@ No modules.
 | [aws_iam_role_policy.this_logs_put_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_lambda_function.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [archive_file.this](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -47,28 +47,65 @@ module "start_ec2_instances" {
   }
 }
 ```
+<!-- BEGIN_TF_DOCS -->
+## Requirements
 
-## Module Input Variables
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 
-| Name                    | Type                             | Default    | Description                                                                                                                 |
-| ----------------------- | -------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------- |
-| schedule_expression     | string                           |  `Not Set` |  The CloudWatch Schedule Expression to trigger the Lambda. Can be a CRON expression for example. _Required_.                |
-| name                    | string                           |  `Not Set` |  The name of the lambda to create. _Required_.                                                                              |
-| tags                    | map(string)                      |  `{}`      |  The tags to assign to the created resources.                                                                               |
-| custom_iam_role_arn     | string                           |  `Not Set` |  The IAM role to assign to the Lambda. If not specified, a role with appropriate permissions will be created.               |
-| action                  | string                           |  `Not Set` |  The action to perform. Valid values are `enable`,`disable`. (`start`, `stop` are supported aliases as well). **Required**. |
-| lookup_resource_tag     | object{key=string, value=string} |  `Not Set` |  The tags to filter on to look for EC2 instances within the regions. **Required**.                                          |
-| lookup_resource_regions | list(string)                     |  `Not Set` | Look for EC2 instances in the specified regions. By default, it uses the region in which the lambda is deployed.            |
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.7.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.82.2 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [archive_file.this](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/resources/file) | resource |
+| [aws_cloudwatch_event_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.this_autoscaling_describe_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.this_ec2_start_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.this_ec2_stop_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.this_logs_put_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_lambda_function.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_action"></a> [action](#input\_action) | The action which the lambda needs to perform. | `string` | n/a | yes |
+| <a name="input_custom_iam_role_arn"></a> [custom\_iam\_role\_arn](#input\_custom\_iam\_role\_arn) | A custom IAM role to execute the lambda. If not specified, a role will be created. | `string` | `null` | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | Optional KMS key ID used to encrypt the logs. | `string` | `null` | no |
+| <a name="input_lookup_resource_regions"></a> [lookup\_resource\_regions](#input\_lookup\_resource\_regions) | A list of regions in which the resources will be looked for. By default, use the current region. | `list(string)` | `null` | no |
+| <a name="input_lookup_resource_tag"></a> [lookup\_resource\_tag](#input\_lookup\_resource\_tag) | The tag to use to search for EC2 instances. | `object({ key = string, value = string })` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name of the lambda to create. | `string` | n/a | yes |
+| <a name="input_retention_in_days"></a> [retention\_in\_days](#input\_retention\_in\_days) | The number of days to retain the logs. | `number` | `7` | no |
+| <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | Define the schedule expression to trigger the lambda. | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to associate to the lambda. | `map(string)` | `{}` | no |
 
 ## Outputs
 
-| Name                  | Type   | Description                                                                                  |
-| --------------------- | ------ | -------------------------------------------------------------------------------------------- |
-| lambda_function_name  | string |  The Lambda function name.                                                                   |
-| lambda_arn            | ARN    |  The Lambda Amazon Resource Identifier.                                                      |
-| lambda_iam_role_arn   | ARN    |  The IAM Role Amazon Resource Identifier assigned to the Lambda.                             |
-| lambda_log_group_name | string |  The CloudWatch Log Group name in which the Lambda push logs.                                |
-| lambda_log_group_arn  | ARN    |  The CloudWatch Log Group Amazon Resource Identifier assigned in which the Lambda push logs. |
+| Name | Description |
+|------|-------------|
+| <a name="output_lambda_arn"></a> [lambda\_arn](#output\_lambda\_arn) | The Lambda ARN. |
+| <a name="output_lambda_function_name"></a> [lambda\_function\_name](#output\_lambda\_function\_name) | The Lambda Function name. |
+| <a name="output_lambda_iam_role_arn"></a> [lambda\_iam\_role\_arn](#output\_lambda\_iam\_role\_arn) | The Lambda IAM role ARN. |
+| <a name="output_lambda_log_group_arn"></a> [lambda\_log\_group\_arn](#output\_lambda\_log\_group\_arn) | The Lambda Log Group ARN. |
+| <a name="output_lambda_log_group_name"></a> [lambda\_log\_group\_name](#output\_lambda\_log\_group\_name) | The name of the Lambda Log Group. |
+<!-- END_TF_DOCS -->
 
 ## Contributing
 

--- a/lambda_function/.pylintrc
+++ b/lambda_function/.pylintrc
@@ -9,6 +9,5 @@ ignore=dist-packages
 ignored-modules=boto3
 disable=
     C0114, # missing-module-docstring
-    R0201, # no-self-use
     R0903, # too-few-public-methods
     R0904, # too-many-public-methods

--- a/lambda_function/src/base.py
+++ b/lambda_function/src/base.py
@@ -35,7 +35,7 @@ class LambdaFunctionBase:
         """ Handle uncatched exceptions. """
         exception_type, exception_value, exception_traceback = sys.exc_info()
         error_traces = traceback.format_exception(exception_type, exception_value, exception_traceback)
-        error_message = '{} {}'.format(exception_type.__name__, str(exception_value))
+        error_message = f'{exception_type.__name__} {str(exception_value)}'
         return {
             'statusCode': 500,
             'body': {

--- a/lambda_function/src/main.py
+++ b/lambda_function/src/main.py
@@ -90,7 +90,7 @@ class CWScheduledEventManageEC2State(LambdaFunctionBase):
         elif self.ACTION in ['disable', 'stop']:
             ec2_instance_state = 'running'
         else:
-            raise Exception('Unexpected action.')
+            raise ValueError('Unexpected action.')
 
         for aws_region_name in self.AWS_REGIONS:
             self.logger.info('> Searching EC2 instances in region %s having tag %s=%s and state=%s.',

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 # Get actual region
 data "aws_region" "this" {}
 
-data "archive_file" "this" {
+resource "archive_file" "this" {
   type        = "zip"
-  source_dir  = "${path.module}/lambda_function/src/"
   output_path = "${path.module}/dist/lambda-code.zip"
+  source_dir  = "${path.module}/lambda_function/src/"
 }
 
 # Allow execution of Lambda from CloudWatch
@@ -137,8 +137,8 @@ resource "aws_iam_role" "this" {
 
 # The lambda execution.
 resource "aws_lambda_function" "this" {
-  filename         = data.archive_file.this.output_path
-  source_code_hash = data.archive_file.this.output_base64sha256
+  filename         = archive_file.this.output_path
+  source_code_hash = archive_file.this.output_base64sha256
   function_name    = var.name
   role             = var.custom_iam_role_arn == null ? aws_iam_role.this[0].arn : var.custom_iam_role_arn
   handler          = "main.lambda_handler"

--- a/main.tf
+++ b/main.tf
@@ -138,15 +138,22 @@ resource "aws_iam_role" "this" {
 
 # The lambda execution.
 resource "aws_lambda_function" "this" {
-  filename         = archive_file.this.output_path
-  source_code_hash = archive_file.this.output_base64sha256
-  function_name    = var.name
-  role             = var.custom_iam_role_arn == null ? aws_iam_role.this[0].arn : var.custom_iam_role_arn
-  handler          = "main.lambda_handler"
-  runtime          = "python3.12"
-  memory_size      = 128
-  timeout          = 300
-  tags             = var.tags
+  filename                       = archive_file.this.output_path
+  source_code_hash               = archive_file.this.output_base64sha256
+  function_name                  = var.name
+  role                           = var.custom_iam_role_arn == null ? aws_iam_role.this[0].arn : var.custom_iam_role_arn
+  handler                        = "main.lambda_handler"
+  runtime                        = "python3.12"
+  memory_size                    = 128
+  reserved_concurrent_executions = 1
+  timeout                        = 300
+  tags                           = var.tags
+  kms_key_arn                    = var.kms_key_id
+
+  tracing_config {
+    mode = "Active"
+  }
+
 
   environment {
     variables = {

--- a/main.tf
+++ b/main.tf
@@ -30,8 +30,9 @@ resource "aws_lambda_permission" "this" {
 # Create a LogGroup for the Lambda
 resource "aws_cloudwatch_log_group" "this" {
   name              = "/aws/lambda/${var.name}"
-  retention_in_days = 7
+  retention_in_days = var.retention_in_days
   tags              = var.tags
+  kms_key_id        = var.kms_key_id
 }
 
 # The lambda IAM role.

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 # Get actual region
 data "aws_region" "this" {}
 
-resource "archive_file" "this" {
+data "archive_file" "this" {
   type        = "zip"
   output_path = "${path.module}/dist/lambda-code.zip"
   source_dir  = "${path.module}/lambda_function/src/"
@@ -138,8 +138,8 @@ resource "aws_iam_role" "this" {
 
 # The lambda execution.
 resource "aws_lambda_function" "this" {
-  filename                       = archive_file.this.output_path
-  source_code_hash               = archive_file.this.output_base64sha256
+  filename                       = data.archive_file.this.output_path
+  source_code_hash               = data.archive_file.this.output_base64sha256
   function_name                  = var.name
   role                           = var.custom_iam_role_arn == null ? aws_iam_role.this[0].arn : var.custom_iam_role_arn
   handler                        = "main.lambda_handler"

--- a/main.tf
+++ b/main.tf
@@ -151,7 +151,7 @@ resource "aws_lambda_function" "this" {
   function_name    = var.name
   role             = var.custom_iam_role_arn == null ? aws_iam_role.this[0].arn : var.custom_iam_role_arn
   handler          = "main.lambda_handler"
-  runtime          = "python3.8"
+  runtime          = "python3.12"
   memory_size      = 128
   timeout          = 300
   tags             = var.tags

--- a/main.tf
+++ b/main.tf
@@ -1,19 +1,10 @@
 # Get actual region
 data "aws_region" "this" {}
 
-# Build Lambda archive
-resource "null_resource" "package_lambda_code" {
-  provisioner "local-exec" {
-    command = "make -C ${path.module}/lambda_function build"
-  }
-}
-
 data "archive_file" "this" {
   type        = "zip"
-  source_dir  = "${path.module}/lambda_function/dist/"
+  source_dir  = "${path.module}/lambda_function/src/"
   output_path = "${path.module}/dist/lambda-code.zip"
-
-  depends_on = [null_resource.package_lambda_code]
 }
 
 # Allow execution of Lambda from CloudWatch
@@ -158,7 +149,6 @@ resource "aws_lambda_function" "this" {
 
   environment {
     variables = {
-      PYTHONPATH               = "./dist-packages"
       PARAM_ACTION             = var.action
       PARAM_RESOURCE_TAG_KEY   = var.lookup_resource_tag.key
       PARAM_RESOURCE_TAG_VALUE = var.lookup_resource_tag.value

--- a/variables.tf
+++ b/variables.tf
@@ -39,3 +39,15 @@ variable "lookup_resource_regions" {
   type        = list(string)
   default     = null
 }
+
+variable "retention_in_days" {
+  type        = number
+  description = "The number of days to retain the logs."
+  default     = 7
+}
+
+variable "kms_key_id" {
+  type        = string
+  description = "Optional KMS key ID used to encrypt the logs."
+  default     = null
+}


### PR DESCRIPTION
Thanks so much for publishing this solution!

While there are other solutions that do this, such as the [Instance Scheduler on AWS ](https://github.com/aws-solutions/instance-scheduler-on-aws/tree/main), they are pretty heavyweight. I really appreciate that this code is small enough to understand and audit, and to apply as a module just where needed.

This updates this in several ways to be more future-proof, as Python 3.8 is now end of life.

* Switches Python version to 3.12
* Removes local-exec processing of zip file and data in favor of using an archive-file data element and just archive the Python files in the src directory. This works better in a [TACOS](https://itnext.io/spice-up-your-infrastructure-as-code-with-tacos-1a9c179e0783) environment where you can't zip files at planning or apply time via external processes.
* Adds some low-effort feaures to help satisfy the checkov security checker
* Maintain docs with [terraform-docs](https://terraform-docs.io/) and `make docs`
